### PR TITLE
fix: loadBalance is deprecated, please use getRandom instead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { Container, loadBalance } from '@cloudflare/containers';
+import { Container, getRandom } from '@cloudflare/containers';
 
 export class WifskiContainer extends Container {
 	defaultPort = 8080;
@@ -17,7 +17,7 @@ export class WifskiContainer extends Container {
 
 export default {
 	async fetch(request: Request, env): Promise<Response> {
-		let container = await loadBalance(env.WIFSKI_CONTAINER, 3);
+		let container = await getRandom(env.WIFSKI_CONTAINER, 3);
 		return await container.fetch(request);
 	},
 } satisfies ExportedHandler<Env>;


### PR DESCRIPTION
Just a fix for this error:
<img width="608" height="215" alt="image" src="https://github.com/user-attachments/assets/c9302c23-f2fe-46e9-ac1f-191363ba15a5" />
